### PR TITLE
HOTFIX: SSH Agent not being passed to yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM renovate/renovate:32.159.4
 COPY bin/ /usr/local/bin/
 COPY config.js .
 
-# Create base directory for renovate so we have somewhere to store the SSH_AUTH_SOCK
-RUN mkdir -p /home/ubuntu/renovate/cache && chown 1000:1000 /home/ubuntu/renovate/cache
+# Create base directory for renovate so we have somewhere to store the sockets
+RUN mkdir -p /home/ubuntu/renovate/sockets && chown 1000:1000 /home/ubuntu/renovate/sockets
 
 # Set platform and base directory
 ENV RENOVATE_PLATFORM="bitbucket"
 ENV RENOVATE_BASE_DIR="/home/ubuntu/renovate"
 
 # Ensure SSH_AUTH_SOCK is shared with compoers, npm, etc
-ENV SSH_AUTH_SOCK=$RENOVATE_BASE_DIR/cache/ssh.sock
-ENV RENOVATE_CUSTOM_ENV_VARIABLES: '{"SSH_AUTH_SOCK":"$RENOVATE_BASE_DIR/cache/ssh.sock"}'
+ENV SSH_AUTH_SOCK=$RENOVATE_BASE_DIR/sockets/ssh.sock
+ENV RENOVATE_CUSTOM_ENV_VARIABLES="{\"SSH_AUTH_SOCK\":\"$RENOVATE_BASE_DIR/sockets/ssh.sock\"}"


### PR DESCRIPTION
This PR fixes issue where the RENOVATE_BASE_DIR path environment variable was not being expanded in the RENOVATE_CUSTOM_ENV_VARIABLES, which looks to be causing an issue with yarn not being able to access private repos when creating PRs.